### PR TITLE
BN-1620_FetchCanonicalHeadId

### DIFF
--- a/proto/node/services/node_rpc.proto
+++ b/proto/node/services/node_rpc.proto
@@ -45,6 +45,9 @@ service NodeRpc {
 
   // retrieve epoch data content
   rpc FetchEpochData (FetchEpochDataReq) returns (FetchEpochDataRes);
+
+  // Retrieve canonical head id
+  rpc FetchCanonicalHeadId (FetchCanonicalHeadIdReq) returns (FetchCanonicalHeadIdRes);
 }
 
 // Request type for BroadcastTransaction
@@ -169,4 +172,14 @@ message FetchEpochDataReq {
 // Response type for FetchEpochDataRes
 message FetchEpochDataRes {
   org.plasmalabs.proto.node.EpochData epochData = 1;
+}
+
+
+// Request type for FetchCanonicalHeadIdReq
+message FetchCanonicalHeadIdReq {}
+
+// Response type for FetchCanonicalHeadIdRes
+message FetchCanonicalHeadIdRes {
+  // Block ID
+  org.plasmalabs.consensus.models.BlockId blockId = 1;
 }


### PR DESCRIPTION
## Purpose

we should expose a fetchCanonicalHeadId which returns JUST the ID. In addition, NodeBlockFetcher should expose fetchCanonicalHeadId. That way, you can compare the actual block IDs instead of just the heights. By comparing just the heights, the node and the indexer may "appear" in sync because the height is the same, but they might have different IDs (thus different chains).

Related PR, https://github.com/PlasmaLaboratories/plasma-node/pull/17

## Tickets

BN-1620
