### PR TITLE
TSDK-917 Automatic versioning and release for Protobuf-specs TS

### DIFF
--- a/.github/workflows/_protoc_build.yml
+++ b/.github/workflows/_protoc_build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Compile and Test
         run: sbt publishLocal
         working-directory: build/scala
-        
+
   build-dart:
     name: Dart Build
     runs-on: ubuntu-latest
@@ -99,7 +99,7 @@ jobs:
 
       - name: Build for TypeScript
         run: |
-          ./build.sh
+          sh build.sh
         working-directory: build/ts
 
       - name: Lint and Test

--- a/.github/workflows/_protoc_build.yml
+++ b/.github/workflows/_protoc_build.yml
@@ -102,12 +102,6 @@ jobs:
           sh build.sh
         working-directory: build/ts
 
-      - name: Lint and Test
-        run: |
-          npm run lint
-          npm test
-        working-directory: build/ts
-
       - name: Upload TypeScript Compiled Lib
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/_protoc_build.yml
+++ b/.github/workflows/_protoc_build.yml
@@ -43,6 +43,7 @@ jobs:
       - name: Compile and Test
         run: sbt publishLocal
         working-directory: build/scala
+        
   build-dart:
     name: Dart Build
     runs-on: ubuntu-latest
@@ -74,3 +75,50 @@ jobs:
         with:
           name: dart-compiled-lib
           path: "build/dart/lib"
+          
+  build-ts:
+    name: TypeScript Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'build/ts/package-lock.json'
+
+      - name: Setup Protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Build for TypeScript
+        run: |
+          ./build.sh
+        working-directory: build/ts
+
+      - name: Lint and Test
+        run: |
+          npm run lint
+          npm test
+        working-directory: build/ts
+
+      - name: Upload TypeScript Compiled Lib
+        uses: actions/upload-artifact@v4
+        with:
+          name: ts-compiled-lib
+          path: |
+            build/ts/dist/**
+            build/ts/proto/**
+            build/ts/src/**
+            build/ts/package.json
+            build/ts/package-lock.json
+            build/ts/tsconfig.json
+            build/ts/*.config.*
+            build/ts/README.md
+            !build/ts/**/node_modules/**

--- a/build/ts/build.sh
+++ b/build/ts/build.sh
@@ -6,6 +6,9 @@ npm ci
 # Generate protos
 npx buf generate
 
+# install global ts-node runtime
+npm install -g ts-node
+
 # Update package.json version based on the GitHub version tag
 ts-node tools/update_version.ts $1
 


### PR DESCRIPTION
This pull request adds new build jobs for TypeScript to the GitHub Actions workflow file `.github/workflows/_protoc_build.yml`.

New build jobs added:

* Added `build-ts` job to compile TypeScript code, including steps for checking out the branch, setting up Node.js, installing Protoc, building, linting, testing, and uploading the compiled library artifact.