### PR TITLE
Automatic versioning for dart and TS and publishing to npm

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
         working-directory: ./build/dart
 
   publish-ts:
-    # if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     name: Publish TypeScript
     needs: build
     runs-on: ubuntu-latest
@@ -96,8 +96,8 @@ jobs:
           npm version $VERSION --no-git-tag-version
         working-directory: ./build/ts
 
-      # - name: Deploy TypeScript (release only)
-      #   run: npm publish --provenance --access public
-      #   working-directory: ./build/ts
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Deploy TypeScript (release only)
+        run: npm publish --provenance --access public
+        working-directory: ./build/ts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,6 +43,16 @@ jobs:
         with:
           name: dart-compiled-lib
           path: build/dart/lib
+
+      - name: Set version from tag
+        run: |
+          # Extract version from git tag
+          VERSION=${GITHUB_REF#refs/tags/}
+          VERSION=${VERSION#v}
+          # Update pubspec.yaml version
+          sed -i "s/^version: .*/version: $VERSION/" pubspec.yaml
+        working-directory: ./build/dart
+  
       - run: dart pub get
         working-directory: ./build/dart
       - name: Deploy Dart (release only)
@@ -73,7 +83,17 @@ jobs:
           name: ts-compiled-lib
           path: build/ts
 
-      - run: npm ci
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Set version from tag
+        run: |
+          # Extract version from git tag (remove 'v' prefix if present)
+          VERSION=${GITHUB_REF#refs/tags/}
+          VERSION=${VERSION#v}
+          # Update package.json version
+          npm version $VERSION --no-git-tag-version
+        working-directory: ./build/ts
 
       - name: Deploy TypeScript (release only)
         run: npm publish --provenance --access public

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,7 +60,7 @@ jobs:
         working-directory: ./build/dart
 
   publish-ts:
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    # if: ${{ startsWith(github.ref, 'refs/tags/') }}
     name: Publish TypeScript
     needs: build
     runs-on: ubuntu-latest
@@ -85,6 +85,7 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        working-directory: ./build/ts
 
       - name: Set version from tag
         run: |
@@ -95,8 +96,8 @@ jobs:
           npm version $VERSION --no-git-tag-version
         working-directory: ./build/ts
 
-      - name: Deploy TypeScript (release only)
-        run: npm publish --provenance --access public
-        working-directory: ./build/ts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # - name: Deploy TypeScript (release only)
+      #   run: npm publish --provenance --access public
+      #   working-directory: ./build/ts
+      #   env:
+      #     NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,3 +48,35 @@ jobs:
       - name: Deploy Dart (release only)
         run: dart pub publish --force
         working-directory: ./build/dart
+
+  publish-ts:
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    name: Publish TypeScript
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ts-compiled-lib
+          path: build/ts
+
+      - run: npm ci
+
+      - name: Deploy TypeScript (release only)
+        run: npm publish --provenance --access public
+        working-directory: ./build/ts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/build/ts/package.json
+++ b/build/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plasma_protobuf",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "A TS library that is generated according to the [Plasma Protobuf specification](https://github.com/PlasmaLaboratories/plasma-protobuf-specs)  This also includes the files required to connect over gRPC to connect to a Node to send transactions, interact with addresses and much more!",
   "main": "dist/src/index.js",
   "module": "dist/index.mjs",


### PR DESCRIPTION
Introduces automatic versioning for TS and dart from the attached github tag. Also introduces a publish step for the TS package to NPM

### Workflow Enhancements:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R46-R102): Added a new job `publish-ts` to publish the TypeScript library, including steps for setting up Node.js, installing dependencies, and deploying the library.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R46-R102): Updated the Dart library deployment to set the version from the git tag before publishing.

### Versioning Updates:
* [`build/ts/package.json`](diffhunk://#diff-e96a56aa49d022e229fe1c93390471b66ad5f97e6477acba0dc94d1246356fc6L3-R3): Changed the initial version to `0.0.0` to hint that the version does not get updated manually, but updated based on the git tag during the deployment process.