### PR TITLE
Update build.sbt

### DIFF
--- a/build/scala/build.sbt
+++ b/build/scala/build.sbt
@@ -1,5 +1,5 @@
 val scala213 = "2.13.11"
-val scala3 = "3.4.1"
+val scala3 = "3.3.4"
 
 inThisBuild(
   List(


### PR DESCRIPTION
## Purpose
 The current recommendation for libraries is to use the latest LTS release (see https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html) unless we are using some new feature of the latest version. Should we go back to the latest LTS release (Scala 3.3.4 LTS) 