### PR TITLE
Allow the dart build tools to support windows file paths

### DIFF
--- a/build/dart/tool/generate_export_files.dart
+++ b/build/dart/tool/generate_export_files.dart
@@ -1,12 +1,13 @@
 import 'dart:io';
+import 'package:path/path.dart' as p;
 
 // Helper utility which generates "export" files for generated protobuf files
 void main() async {
   final wd = Directory.current;
-  final srcDir = Directory('${wd.path}/lib/src');
+  final srcDir = Directory(p.join(wd.path, 'lib', 'src'));
   final files = await srcDir
       .list(recursive: true)
-      .where((e) => e.path.endsWith(".dart"))
+      .where((e) => e.path.endsWith('.dart'))
       .toList();
 
   await exportStrataLib(wd, files);
@@ -16,23 +17,23 @@ void main() async {
 Future<void> exportStrataLib(
     Directory wd, Iterable<FileSystemEntity> files) async {
   final strataExportLines = files
-      .where((e) => !e.path.startsWith("${wd.path}/lib/src/google"))
+      .where((e) => !e.path.startsWith(p.join(wd.path, 'lib', 'src', 'google')))
       .map((e) {
     final path = e.path;
-    return "export '${path.substring(wd.path.length + 5)}';";
+    return "export '${p.relative(path, from: p.join(wd.path, 'lib')).replaceAll(r'\', '/')}';";
   }).join('\n');
-  final strataOutput = File('${wd.path}/lib/plasma_protobuf.dart');
+  final strataOutput = File(p.join(wd.path, 'lib', 'plasma_protobuf.dart'));
   await strataOutput.writeAsString(strataExportLines);
 }
 
 Future<void> exportGoogleLib(
     Directory wd, Iterable<FileSystemEntity> files) async {
   final googleExportLines = files
-      .where((e) => e.path.startsWith("${wd.path}/lib/src/google"))
+      .where((e) => e.path.startsWith(p.join(wd.path, 'lib', 'src', 'google')))
       .map((e) {
     final path = e.path;
-    return "export '${path.substring(wd.path.length + 5)}';";
+    return "export '${p.relative(path, from: p.join(wd.path, 'lib')).replaceAll(r'\', '/')}';";
   }).join('\n');
-  final googleOutput = File('${wd.path}/lib/google_protobuf.dart');
+  final googleOutput = File(p.join(wd.path, 'lib', 'google_protobuf.dart'));
   await googleOutput.writeAsString(googleExportLines);
 }


### PR DESCRIPTION
Previous implementation would only work with Linux filesystem structures.
Using the official path lib allows for platform-independent execution

* Replaced string concatenations with `p.join` for constructing paths, ensuring platform independence. [[1]](diffhunk://#diff-cb93acb3ecf1bbe3ade64d204adf7dc6022784dc0459e54565e0559a987b1a0cR2-R10) [[2]](diffhunk://#diff-cb93acb3ecf1bbe3ade64d204adf7dc6022784dc0459e54565e0559a987b1a0cL19-R37)
* Updated the logic for generating export statements to use `p.relative` and `replaceAll` to handle path separators correctly across different platforms.